### PR TITLE
Add tooltip to video captions

### DIFF
--- a/app/views/shared/_video.html.slim
+++ b/app/views/shared/_video.html.slim
@@ -5,7 +5,7 @@
         img.responsive-img src="#{video.image2}" alt="#{video.title}"
     .card-content
       a href=video_path(video)
-        span.video-title.card-title.grey-text.text-darken-4.truncate
+        span.video-title.card-title.grey-text.text-darken-4.truncate title="#{video.title}"
           = video.title
     .card-action
       a.watch-video href=video_path(video) data-video-title="#{video.title}" data-video-id="#{video.video_id}" Watch


### PR DESCRIPTION
Since the video captions are truncated, this will enable users to see
the full title as a tooltip.