### PR TITLE
Fixed navbar cutting into branding

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -48,6 +48,19 @@ video{
   }
 }
 
+// Prevents the nav bar buttons from cutting into the branding
+ul.nav-mobile {
+
+  a {
+    padding: 0 12px;
+  }
+
+  i {
+    margin-right: 5px;
+  }
+
+}
+
 @media screen and (max-width: 1200px){
   .nav-mobile span{
     display: none;


### PR DESCRIPTION
On some display edge cases, the navbar cuts into the branding (due to the added support link)

<img width="953" alt="screen shot 2016-08-28 at 9 19 18 pm" src="https://cloud.githubusercontent.com/assets/347918/18038397/94ca02fc-6d65-11e6-8bb0-cb881bc44e21.png">

I've reduced the padding between the icon and the span label, and reduced the margin between each navbar link.

This is the closest it gets before the span labels disappear:

<img width="868" alt="screen shot 2016-08-28 at 9 19 44 pm" src="https://cloud.githubusercontent.com/assets/347918/18038406/a99b17b6-6d65-11e6-89f5-4819be96deba.png">
