### PR TITLE
Organization Alias Support

### DIFF
--- a/app/admin/organization.rb
+++ b/app/admin/organization.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Organization do
-  permit_params :id, :title, :description, :website, :twitter, :contact_person, :image, :active
+  permit_params :id, :title, :description, :website, :twitter, :contact_person, :image, :active, :slug
   config.sort_order = 'title_asc'
 
   filter :title
@@ -29,7 +29,7 @@ ActiveAdmin.register Organization do
       end
     end
 
-    redirect_to collection_path, alert: "Organizations have been merged."
+    redirect_to collection_path, alert: 'Organizations have been merged.'
   end
 
   index do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,16 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  protected
+
+  def is_number?(string)
+    no_commas =  string.gsub(',', '')
+    matches = no_commas.match(/-?\d+(?:\.\d+)?/)
+    if !matches.nil? && matches.size == 1 && matches[0] == no_commas
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -31,14 +31,4 @@ class EpisodesController < ApplicationController
   def search_param
     params.permit(:search)
   end
-
-  def is_number?(string)
-    no_commas =  string.gsub(',', '')
-    matches = no_commas.match(/-?\d+(?:\.\d+)?/)
-    if !matches.nil? && matches.size == 1 && matches[0] == no_commas
-      true
-    else
-      false
-    end
-  end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -4,13 +4,17 @@ class OrganizationsController < ApplicationController
   end
 
   def show
-    @organization = Organization.find(params[:id])
-    return redirect_to(organizations_path) unless @organization.active?
+    @organization = is_number?(params[:id]) ? Organization.find(params[:id]) : Organization.find_by_slug(params[:id])
+    return redirect_to(organizations_path) if @organization.nil? || !@organization.active?
     @episodes = @organization.episodes.active.order('published_at DESC')
   end
 
   def alias
     @organization = Organization.find(params[:id])
-    redirect_to organization_name_path(name: @organization.title.parameterize, id: @organization.id)
+    if @organization.slug.present?
+      redirect_to organization_slug_path(id: @organization.slug)
+    else
+      redirect_to organization_name_path(name: @organization.title.parameterize, id: @organization.id)
+    end
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -8,4 +8,9 @@ class OrganizationsController < ApplicationController
     return redirect_to(organizations_path) unless @organization.active?
     @episodes = @organization.episodes.active.order('published_at DESC')
   end
+
+  def alias
+    @organization = Organization.find(params[:id])
+    redirect_to organization_name_path(name: @organization.title.parameterize, id: @organization.id)
+  end
 end

--- a/app/views/organizations/index.html.slim
+++ b/app/views/organizations/index.html.slim
@@ -20,13 +20,13 @@
       p The local tech and startup communities that we support.
     - @organizations.each do |organization|
       .col.s6.l3.m4
-        a href=organization_path(organization)
+        a href=organization_alias_path(organization)
           h5.truncate= organization.title
           .thumbnail
             img.responsive-img src=organization.image
   .row
     - @no_logo.each do |organization|
       .col.s6.l4
-        a href=organization_path(organization)
+        a href=organization_alias_path(organization)
           h5.truncate= organization.title
 

--- a/app/views/organizations/show.html.slim
+++ b/app/views/organizations/show.html.slim
@@ -2,7 +2,7 @@
   meta property="og:site_name" content="Engineers.SG"
   meta property="og:title" content="Organization: #{@organization.title} - Engineers.SG" /
   meta property="og:description" content=(@organization.description.present? ? @organization.description : 'One of the local tech and startup community that we support.') /
-  meta property="og:url" content=organization_url(@organization) /
+  meta property="og:url" content=organization_alias_url(name: @organization.title.parameterize, id: @organization.id) /
   meta property="og:image" content=(@organization.image.present? ? @organization.image : 'https://pbs.twimg.com/profile_images/530374167581843459/LhAoHDYO.jpeg') /
   meta property="og:type" content="website" /
   meta property="fb:app_id" content="1636558033282778" /
@@ -12,6 +12,8 @@
   meta name="twitter:title" content="Organization: #{@organization.title} - Engineers.SG" /
   meta name="twitter:description" content=(@organization.description.present? ? @organization.description : 'One of the local tech and startup community that we support.') /
   meta name="twitter:image" content=(@organization.image.present? ? @organization.image : 'https://pbs.twimg.com/profile_images/530374167581843459/LhAoHDYO.jpeg') /
+
+  link rel="canonical" href=organization_alias_url(name: @organization.title.parameterize, id: @organization.id) /
 
 .container
   .row

--- a/app/views/shared/_video.html.slim
+++ b/app/views/shared/_video.html.slim
@@ -20,10 +20,10 @@
             .row.valign-wrapper
               - if organization.image.present?
                 .col.s4
-                  a href=organization_path(organization)
+                  a href=organization_alias_path(organization)
                     img.responsive-img.circle src=organization.image
               .col class=(organization.image.present? ? 's8' : 's12')
-                a href=organization_path(organization)
+                a href=organization_alias_path(organization)
                   h6=organization.title
 
         - presenter = video.presenters.try(:first)

--- a/app/views/shared/_video_large.html.slim
+++ b/app/views/shared/_video_large.html.slim
@@ -27,10 +27,10 @@
           .row.valign-wrapper
             - if organization.image.present?
               .col.s4
-                a href=organization_path(organization)
+                a href=organization_alias_path(organization)
                   img.responsive-img.circle src=organization.image
             .col class=(organization.image.present? ? 's8' : 's12')
-              a href=organization_path(organization)
+              a href=organization_alias_path(organization)
                 h6=organization.title
 
       - presenter = video.presenters.try(:first)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get 'conference/:id', to: 'episodes#playlist', as: 'conference'
   get 'feed', to: 'episodes#index', format: 'atom'
 
-  resources :organizations, only: [:index, :show]
+  resources :organizations, only: [:index]
   resources :subscribers, only: [:create]
 
   root 'welcome#index'
@@ -38,6 +38,10 @@ Rails.application.routes.draw do
   get 'presenter/:id', to: 'presenters#slug', as: 'presenter_slug'
 
   get '/video/new-directions-in-cryptography-papers-we-love', to: redirect('/video/new-directions-in-cryptography-papers-we-love--601')
+
+  get 'organization/*name--:id', to: 'organizations#show', as: 'organization_name'
+  get 'organizations/:id', to: 'organizations#alias', as: 'organization_show', constraints: { id: /[0-9]+/ }
+  get 'organization/:id', to: 'organizations#alias', as: 'organization_alias', constraints: { id: /[0-9]+/ }
 
   if Rails.env.development?
     get 'googleauth/start', to: 'google_auth#start'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,10 @@ Rails.application.routes.draw do
   get 'organization/*name--:id', to: 'organizations#show', as: 'organization_name'
   get 'organizations/:id', to: 'organizations#alias', as: 'organization_show', constraints: { id: /[0-9]+/ }
   get 'organization/:id', to: 'organizations#alias', as: 'organization_alias', constraints: { id: /[0-9]+/ }
+  get 'org/:id', to: 'organizations#alias', constraints: { id: /[0-9]+/ }
+  get 'o/:id', to: 'organizations#alias', constraints: { id: /[0-9]+/ }
+  get 'organizations/:id', to: 'organizations#show', as: 'organization_show_slug'
+  get 'organization/:id', to: 'organizations#show', as: 'organization_slug'
 
   if Rails.env.development?
     get 'googleauth/start', to: 'google_auth#start'

--- a/db/migrate/20161113082712_add_slug_to_organizations_table.rb
+++ b/db/migrate/20161113082712_add_slug_to_organizations_table.rb
@@ -1,0 +1,6 @@
+class AddSlugToOrganizationsTable < ActiveRecord::Migration
+  def change
+    add_column :organizations, :slug, :string, null: true
+    add_index :organizations, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161112153420) do
+ActiveRecord::Schema.define(version: 20161113082712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,8 +86,10 @@ ActiveRecord::Schema.define(version: 20161112153420) do
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false
     t.string   "image"
+    t.string   "slug"
   end
 
+  add_index "organizations", ["slug"], name: "index_organizations_on_slug", using: :btree
   add_index "organizations", ["twitter"], name: "index_organizations_on_twitter", using: :btree
 
   create_table "playlist_categories", force: :cascade do |t|


### PR DESCRIPTION
- `/organizations/:id` should redirect to `/organization/:*name--:id` (eg. `/organizations/122` redirects to `/organizations/coding-girls--122`
- Interchangeability of `/organizations/:id`, `/organization/:id`, `/org/:id` and `/o/:id`
- Support for slugs (if added in Admin panel): `/organization/singaporejs`