### PR TITLE
📺 Allow fullscreen videos in IFRAME embedded players

### DIFF
--- a/app/views/episodes/show.html.slim
+++ b/app/views/episodes/show.html.slim
@@ -27,7 +27,7 @@
             - if @video.video_site == 'youtube'
               #player
             - elsif @video.video_site == 'vimeo'
-              iframe allowfullscreen="" frameborder="0" height="281" mozallowfullscreen="" src="https://player.vimeo.com/video/#{@video.video_id}" webkitallowfullscreen="" width="500"
+              iframe allowfullscreen=true frameborder="0" height="281" src="https://player.vimeo.com/video/#{@video.video_id}" width="500"
       .row
         .col.s12.m6.share-stats
           .share-btn

--- a/app/views/shared/_video_large.html.slim
+++ b/app/views/shared/_video_large.html.slim
@@ -2,9 +2,9 @@
   .card-image
     .video.video-container
       - if video.video_site == 'youtube'
-        iframe width="560" height="315" src="https://www.youtube.com/embed/#{video.video_id}" frameborder="0" allowfullscreen
+        iframe allowfullscreen=true frameborder="0" width="560" height="315" src="https://www.youtube.com/embed/#{video.video_id}"
       - elsif video.video_site == 'vimeo'
-        iframe allowfullscreen="" frameborder="0" height="281" mozallowfullscreen="" src="https://player.vimeo.com/video/#{video.video_id}" webkitallowfullscreen="" width="500"
+        iframe allowfullscreen=true frameborder="0" width="500" height="281" src="https://player.vimeo.com/video/#{video.video_id}"
   .card-content
     .row
       .col.s12

--- a/app/views/welcome/live.html.slim
+++ b/app/views/welcome/live.html.slim
@@ -20,4 +20,4 @@
   .row
     .col.s12
       .video-container
-        iframe width="560" height="315" src="https://www.youtube.com/embed/5Lm1UMogEkI?vq=hd720" frameborder="0" allowfullscreen
+        iframe allowfullscreen=true frameborder="0" width="560" height="315" src="https://www.youtube.com/embed/5Lm1UMogEkI?vq=hd720"


### PR DESCRIPTION
This should help to enable fullscreen playback on Youtube embeds. (Could still fail if video permissions are configured to disallow fullscreen playback.)

Seems like Slim language requires a value, otherwise the attribute is ignored. For boolean attribute this means either `foo=""` or `foo=true`.

#### Reference

- https://github.com/slim-template/slim#boolean-attributes
- https://support.google.com/youtube/answer/6276924