### PR TITLE
Remove link back

### DIFF
--- a/app/views/welcome/events.html.slim
+++ b/app/views/welcome/events.html.slim
@@ -7,13 +7,6 @@
       p The Singapore Tech scene is indeed vibrant. Just look at the sheer number of events listed on these fabulous websites.
 
     .col.s12
-      h4 WeBuild.SG
-
-      p
-        a> (href="https://webuild.sg/" target="_blank") WeBuild.SG
-        | is a list of free open events and open source libraries for the curious folks who love to make things!
-
-    .col.s12
       ul.collection
         - cache('all_events') do
           == render partial: 'shared/event_with_map', collection: @events, as: :event


### PR DESCRIPTION
`webuild.sg` domain will be re-directed to `engineers.sg/events`. Hence, the link is removed.

Unsure which branch is being deployed. Please feel free to merge to the appropriate branch 🙇‍♀️ 

Thanks @miccheng 🙇‍♀️ 🙏 