### PR TITLE
Show a heading for each day in the events list

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -112,15 +112,15 @@ ul.nav-mobile {
     border: none;
     .date-marker {
         border: none;
-        padding: 10px 40px !important;
+        padding: 10px 40px;
         // WeBuild tribute red:
         // background-color: #C11A18 !important;
         // Engineers.SG blue:
-        background-color: #3C74A3 !important;
+        background-color: #3C74A3;
         color: white;
         font-weight: bold;
         &:not(:first-child) {
-            margin-top: 3em !important;
+            margin-top: 3em;
         }
     }
     .event-item {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -108,22 +108,21 @@ ul.nav-mobile {
     }
 }
 
-.date-marker {
-    border: none;
-    padding: 10px 40px !important;
-    // WeBuild tribute red:
-    // background-color: #C11A18 !important;
-    // Engineers.SG blue:
-    background-color: #3C74A3 !important;
-    color: white;
-    font-weight: bold;
-    &:not(:first-child) {
-        margin-top: 3em !important;
-    }
-}
-
 .events-list {
     border: none;
+    .date-marker {
+        border: none;
+        padding: 10px 40px !important;
+        // WeBuild tribute red:
+        // background-color: #C11A18 !important;
+        // Engineers.SG blue:
+        background-color: #3C74A3 !important;
+        color: white;
+        font-weight: bold;
+        &:not(:first-child) {
+            margin-top: 3em !important;
+        }
+    }
     .event-item {
         border: 1px solid #e0e0e0;
         border-top: none;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -108,6 +108,21 @@ ul.nav-mobile {
     }
 }
 
+.date-marker {
+    border: none;
+    padding: 10px 40px !important;
+    // WeBuild tribute red:
+    // background-color: #C11A18 !important;
+    // Engineers.SG blue:
+    background-color: #3C74A3 !important;
+    color: white;
+    font-weight: bold;
+    margin-bottom: 1em !important;
+    &:not(:first-child) {
+        margin-top: 3em !important;
+    }
+}
+
 img[usemap],
 map area {
     outline: none;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -117,9 +117,21 @@ ul.nav-mobile {
     background-color: #3C74A3 !important;
     color: white;
     font-weight: bold;
-    margin-bottom: 1em !important;
     &:not(:first-child) {
         margin-top: 3em !important;
+    }
+}
+
+.events-list {
+    border: none;
+    .event-item {
+        border: 1px solid #e0e0e0;
+        border-top: none;
+        margin: 0;
+        padding: 20px 20px;
+        h5 {
+            margin-top: 0;
+        }
     }
 }
 

--- a/app/views/shared/_event_with_map.html.slim
+++ b/app/views/shared/_event_with_map.html.slim
@@ -1,4 +1,4 @@
-li.row.collection-item
+li.row.collection-item.event-item
   div.col.s12.l7
     h5=event["name"]
     blockquote= event["group_name"]

--- a/app/views/welcome/events.html.slim
+++ b/app/views/welcome/events.html.slim
@@ -15,7 +15,7 @@
         | )
 
     .col.s12
-      ul.collection
+      ul.collection.events-list
         - current_day = ''
         - cache('all_events') do
           - @events.each do |event|

--- a/app/views/welcome/events.html.slim
+++ b/app/views/welcome/events.html.slim
@@ -16,8 +16,17 @@
 
     .col.s12
       ul.collection
+        - current_day = ''
         - cache('all_events') do
-          == render partial: 'shared/event_with_map', collection: @events, as: :event
+          - @events.each do |event|
+            - event_time = Time.at(event['unix_start_time'])
+            - event_day = event_time.strftime("%A, #{event_time.day.ordinalize} %B")
+            - if event_day != current_day
+              - current_day = event_day
+              li.row.collection-item.date-marker
+                h5 = current_day
+
+            == render partial: 'shared/event_with_map', locals: { event: event }
 
     .col.s12
       .collection


### PR DESCRIPTION
Browsing the current layout, I find it difficult to see when one day ends and the next day begins:

<img width="300" src="https://user-images.githubusercontent.com/911799/44828462-94466980-ac4a-11e8-85bd-0ec76dcf9e9b.png">

So I added a clear heading (and a gap) when each new day starts:

<img width="300" src="https://user-images.githubusercontent.com/911799/44828905-9b6e7700-ac4c-11e8-8383-e917f2e4c48f.png">

Of course this does eat up some screen space, but I think it conveys useful information.

I hope you like it. I am sorry there are so many lines of code! (I had to override some of the default CSS rules.)