### PR TITLE
[Fix #38] Fix side navigation not working on mobile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'jbuilder'
 gem 'kaminari'
 
 gem "slim-rails"
-gem 'materialize-sass', '~> 0.97.5'
+gem 'materialize-sass', '~> 0.100'
 gem 'autoprefixer-rails'
 gem 'therubyracer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,7 +194,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    materialize-sass (0.97.8)
+    materialize-sass (0.100.2)
       sass (~> 3.3)
     memoist (0.16.0)
     memoizable (0.4.2)
@@ -332,7 +332,7 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    sass (3.5.7)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -424,7 +424,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   loofah (>= 2.2.3)
-  materialize-sass (~> 0.97.5)
+  materialize-sass (~> 0.100)
   omniauth
   omniauth-twitter
   pg (~> 0.21.0)
@@ -454,4 +454,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,10 +17,11 @@
 //= require react_ujs
 //= require components
 //= require lodash.core
-//= require_tree .
 
 $(document).ready(function() {
-    Materialize.updateTextFields();
-    $(".button-collapse").sideNav();
-    $('select').material_select();
+  Materialize.updateTextFields();
+  $(".button-collapse").sideNav();
+  $('select').material_select();
 });
+
+//= require_tree .

--- a/app/views/shared/_nav_bar.html.slim
+++ b/app/views/shared/_nav_bar.html.slim
@@ -5,6 +5,7 @@ nav
 
       a.button-collapse href="#" data-activates="mobile-nav"
         i.material-icons menu
+
       ul.nav-mobile.right.hide-on-med-and-down
         li
           a href="/episodes/" title="Videos"


### PR DESCRIPTION
The side navigation is broken because the Materialize jQuery plugin isn't found on the global jQuery object:

<img width="380" alt="screenshot 2018-12-05 at 10 47 56" src="https://user-images.githubusercontent.com/5259935/49487809-0ac4ba00-f87f-11e8-8f26-ae49decd5ba6.png">

I suspect there's something about the order of the assets loading that overwrites the original jQuery object. Placing initialization before the `require_tree` directive solves the issue for now. This isn't a final fix, but at least it gets the side navigation working:

![sidenav](https://user-images.githubusercontent.com/5259935/49487833-28921f00-f87f-11e8-9eb2-df9f77147964.gif)

It's probably a good idea to upgrade Materialize to 1.0 now.