### PR TITLE
Upgrade Rack with latest security patch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-cors (1.0.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -454,4 +454,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
This upgrades Rack from `1.6.10` to `1.6.11` and patches a known vulnerability:

<img width="713" alt="screenshot 2018-12-05 at 11 20 42" src="https://user-images.githubusercontent.com/5259935/49488023-f208d400-f87f-11e8-8d3d-f0a8c1609b17.png">
