### PR TITLE
Don't inspect LoDash vendor JavaScript in CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -42,6 +42,6 @@ exclude_paths:
 - spec/**/*
 - vendor/**/*
 - app/assets/javascripts/chosen.jquery.js
+- app/assets/javascripts/lodash.core.js
 - app/assets/stylesheets/chosen.css
 - .rubocop.yml
-


### PR DESCRIPTION
The CodeClimate score is a bit unfair to us, because it's analyzing the LoDash vendor JavaScript. 😉 