### PR TITLE
Change FactoryGirl to latest FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'better_errors'
   gem 'spring-commands-rspec'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'faker'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,10 +107,10 @@ GEM
     erubi (1.7.1)
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     faker (1.8.7)
       i18n (>= 0.7)
@@ -414,7 +414,7 @@ DEPENDENCIES
   cancancan
   devise
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   faker
   feature
   foreman
@@ -454,4 +454,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/spec/factories/episode.rb
+++ b/spec/factories/episode.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :episode do
     video_id { SecureRandom::hex(10) }
     title { Faker::Name.name }

--- a/spec/factories/presenter.rb
+++ b/spec/factories/presenter.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :presenter do
     name { Faker::Name.name }
 

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Episode, type: :model do
 
   describe 'scope' do
     describe 'active' do
-      let!(:video1) { FactoryGirl.create :episode, active: true }
-      let!(:video2) { FactoryGirl.create :episode, active: false }
+      let!(:video1) { FactoryBot.create :episode, active: true }
+      let!(:video2) { FactoryBot.create :episode, active: false }
       it 'only shows active' do
         expect(Episode.active).to contain_exactly video1
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,5 +62,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
This gem name was changed by ThoughtBot. This update removes the deprecation warning by upgrading to the latest version.