### PR TITLE
Replace omniauth with new omniauth-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'active_admin-sortable_tree'
 gem 'devise'
 gem 'cancancan'
 gem 'feature'
-gem 'omniauth'
+gem 'omniauth-rails'
 gem 'omniauth-twitter'
 gem 'twitter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,6 +236,9 @@ GEM
     omniauth-oauth (1.1.0)
       oauth
       omniauth (~> 1.0)
+    omniauth-rails (0.6.0)
+      omniauth
+      rails
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
@@ -453,7 +456,7 @@ DEPENDENCIES
   listen
   loofah (>= 2.2.3)
   materialize-sass (~> 0.100)
-  omniauth
+  omniauth-rails
   omniauth-twitter
   pg (~> 0.21.0)
   pry


### PR DESCRIPTION
### Background

The `omniauth` gem, when used with Rails specifically, has a security vulnerability that won't be fixed. Instead they [recommend using `omniauth-rails` instead](https://github.com/omniauth/omniauth/pull/809).

### Approach

Replace `omniauth` with `omniauth-rails`.