### PR TITLE
Remove unmaintained sortable_tree Gem since it isn't in use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'rails_autolink'
 gem 'puma'
 
 gem 'activeadmin', '~> 1.4.3'
-gem 'active_admin-sortable_tree'
 gem 'devise'
 gem 'cancancan'
 gem 'feature'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,9 @@ GEM
     byebug (10.0.2)
     cancancan (2.2.0)
     coderay (1.1.2)
-    coffee-rails (4.2.2)
+    coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
+      railties (>= 5.2.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs

--- a/app/admin/featured_video.rb
+++ b/app/admin/featured_video.rb
@@ -3,7 +3,6 @@ ActiveAdmin.register FeaturedVideo do
 
   config.filters = false
   config.sort_order = 'sequence_asc'
-  sortable tree: false, sorting_attribute: :sequence
 
   index do
     selectable_column
@@ -15,13 +14,6 @@ ActiveAdmin.register FeaturedVideo do
     end
     column :sequence
     column :active
-    actions
-  end
-
-  index as: :sortable do
-    label do |t|
-      "#{t.episode.title}"
-    end
     actions
   end
 

--- a/app/assets/javascripts/active_admin.js
+++ b/app/assets/javascripts/active_admin.js
@@ -1,4 +1,5 @@
 //= require active_admin/base
+//= require chosen.jquery.js
 
 $(document).ready(function(){
   var chosen_option = {

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -10,6 +10,7 @@
 // Active Admin's got SASS!
 @import "active_admin/mixins";
 @import "active_admin/base";
+@import "chosen.css";
 
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -189,8 +189,8 @@ ActiveAdmin.setup do |config|
   #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
   #
   # To load a javascript file:
-  config.register_javascript 'chosen.jquery.js'
-  config.register_stylesheet 'chosen.css'
+  # config.register_javascript 'chosen.jquery.js'
+  # config.register_stylesheet 'chosen.css'
 
   # == CSV options
   #


### PR DESCRIPTION
### Background

On a quest to upgrade all the things. No more security alerts.

### Approach

- Change use of deprecated JS and CSS registration for ActiveAdmin.
- Remove unmaintained and unused sortable_tree gem.

### Verification

Manual testing. All pages and functionality work fine locally.