### PR TITLE
Replace redis-rails with redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'twitter'
 
 gem "gibbon"
 gem "rest-client"
-gem "redis-rails"
+gem "redis"
 gem 'acts-as-taggable-on'
 gem 'react-rails', '~> 1.4', '>= 1.4.1'
 gem 'rack-cors', require: 'rack/cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,22 +303,6 @@ GEM
       railties (>= 3.2)
       tilt
     redis (4.1.3)
-    redis-actionpack (5.1.0)
-      actionpack (>= 4.0, < 7)
-      redis-rack (>= 1, < 3)
-      redis-store (>= 1.1.0, < 2)
-    redis-activesupport (5.2.0)
-      activesupport (>= 3, < 7)
-      redis-store (>= 1.3, < 2)
-    redis-rack (2.0.6)
-      rack (>= 1.5, < 3)
-      redis-store (>= 1.2, < 2)
-    redis-rails (5.0.2)
-      redis-actionpack (>= 5.0, < 6)
-      redis-activesupport (>= 5.0, < 6)
-      redis-store (>= 1.2, < 2)
-    redis-store (1.8.1)
-      redis (>= 4, < 5)
     ref (2.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -463,7 +447,7 @@ DEPENDENCIES
   rails_12factor
   rails_autolink
   react-rails (~> 1.4, >= 1.4.1)
-  redis-rails
+  redis
   rest-client
   rspec-rails
   sass-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_store, ENV["REDIS_URL"], { expires_in: 60.minutes }
+  config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: 60.minutes }
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
### Background

Starting with version 5.2, [Rails has its own built-in cache store](https://github.com/redis-store/redis-rails#a-quick-note-about-rails-52) for Redis.

Because of this, there is no `redis-rails` for Rails 6. So we need to switch to the Rails native store.

### Approach

- Switch out `redis-rails` with `redis`.
- Change cache store from `redis_store` to `redis_cache_store`.