### PR TITLE
Remove Foreman from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ group :test do
 end
 
 group :development do
-  gem 'foreman'
   gem 'spring'
   gem 'seed_dump'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,8 +117,6 @@ GEM
       multipart-post (>= 1.2, < 3)
     feature (1.4.0)
     ffi (1.11.3)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -423,7 +421,6 @@ DEPENDENCIES
   factory_bot_rails
   faker
   feature
-  foreman
   gibbon
   google-api-client (~> 0.11)
   jbuilder


### PR DESCRIPTION
### Background

It is highly recommended to [not bundle Foreman](https://github.com/ddollar/foreman/wiki/Don't-Bundle-Foreman). Doing so also blocks upgrade to Rails 6.

### Implications

Developers can still use Foreman, but installed in their system-wide gemset.